### PR TITLE
New query syntax with operators and modifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
-language: cpp
-compiler:
-  - clang
+language: julia
+os:
+    - linux
+julia:
+    - 0.4
+    - nightly
+services:
+    - mongodb
 notifications:
-  email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    email: false
+sudo: false
 script:
-  - julia -e 'Pkg.init()'
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("Mongo")'
-  - julia -e 'Pkg.add("FactCheck"); Pkg.add("BinDeps"); Pkg.add("LibBSON")'
-  - julia -e 'Pkg.test("Mongo", coverage=true)'
+    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - julia -e 'Pkg.clone(pwd()); Pkg.build("Mongo")'
+    - julia -e 'Pkg.add("FactCheck"); Pkg.add("BinDeps"); Pkg.add("LibBSON")'
+    - julia -e 'Pkg.test("Mongo", coverage=true)'
 after_success:
-- if [ $JULIAVERSION = "juliareleases" ]; then julia -e 'cd(Pkg.dir("Mongo")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi
+    - if [ $JULIAVERSION = "juliareleases" ]; then julia -e 'cd(Pkg.dir("Mongo")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi

--- a/README.md
+++ b/README.md
@@ -29,37 +29,45 @@ You must have a MongoDB server running somewhere.  You can specify the host and 
 Getting Started
 ---------------
 
-    using Mongo, LibBSON
+````julia
+using Mongo, LibBSON
 
-    # Create a client connection
-    client = MongoClient() # default locahost:27017
+# Create a client connection
+client = MongoClient() # default locahost:27017
 
-    # Get a handle to collection named "cats" in database "db"
-    collection = MongoCollection(client, "db", "cats")
+# Get a handle to collection named "cats" in database "db"
+collection = MongoCollection(client, "db", "cats")
 
-    # Insert a document
-    # Mokie is a pretty old cat
-    oid = insert(collection, Dict("name"=>"Mokie", "age"=>17))
+# Insert a document
+# Mokie is a pretty old cat
+m_oid = insert(collection, Dict("name"=>"Mokie", "age"=>17))
+# Pebbles is an even older cat
+p_oid = insert(collection, Dict("name"=>"Pebbles", "age"=>19))
 
-    # Ensure it was inserted by counting
-    println(count(collection, Dict("name"=>"Mokie")))
-    println(count(collection, Dict("_id"=>oid)))
+# Ensure they were inserted by counting
+println(count(collection, Dict("name"=>"Mokie")))
+println(count(collection))
 
-    # Print all the documents with a name of Mokie
-    for doc in find(collection, Dict("name"=>"Mokie"))
-        println(doc)
-    end
+# Print all cats under age 19
+# The query function returns a pair with the key "$query"
+# There are functional shortcuts for many MongoDB modifiers and operators, here
+# we use $lt
+for doc in find(collection, query("age" => lt(19)))
+    println("$(doc["name"]) is younger than 19")
+end
 
-    # It's Mokie's birthday!
-    # Update the document and print the new docs
-    update(collection, Dict("_id"=>oid), Dict("age"=>18))
-    for doc in find(collection, Dict("name"=>"Mokie"))
-        println(doc)
-    end
+# It's Mokie's birthday!
+# We can use the shortcut for the "$inc" operator to increase Mokie's age by 1
+# Notice how we can use a Tuple as our query instead of typing "Dict" over and over
+update(collection, ("_id"=>m_oid), inc("age"=>1))
+for doc in find(collection, Dict("name"=>"Mokie"))
+    println(doc)
+end
 
-    # Delete the document and ensure it is no more by counting
-    delete(collection, Dict("_id"=>oid))
-    println(count(collection, Dict("name"=>"Mokie")))
+# Delete the document and ensure it is no more by counting
+delete(collection, Dict("_id"=>m_oid))
+println(count(collection, Dict("name"=>"Mokie")))
+````
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ Setup
 
 You must have a MongoDB server running somewhere.  You can specify the host and port in the MongoClient constructor, otherwise it uses the Mongo default locahost:27017.
 
-
-Getting Started
----------------
-
 ````julia
 using Mongo, LibBSON
 
@@ -36,37 +32,66 @@ using Mongo, LibBSON
 client = MongoClient() # default locahost:27017
 
 # Get a handle to collection named "cats" in database "db"
-collection = MongoCollection(client, "db", "cats")
+cats = MongoCollection(client, "db", "cats")
 
 # Insert a document
 # Mokie is a pretty old cat
-m_oid = insert(collection, Dict("name"=>"Mokie", "age"=>17))
+m_oid = insert(cats, Dict("name" => "Mokie", "age" => 17))
+````
+
+Dictionary Syntax
+-----------------
+
+With MongoDB, documents and queries are represented as `BSONObject` structures.
+In Julia, we can create these from `Associative` data structures like `Dict`.
+However, most functions in this package also accept a `Union{Pair,Tuple}` in
+lieu of that, allowing us to omit the `Dict` constructor:
+
+````julia
 # Pebbles is an even older cat
-p_oid = insert(collection, Dict("name"=>"Pebbles", "age"=>19))
+p_oid = insert(cats, ("name" => "Pebbles", "age" => 19))
 
 # Ensure they were inserted by counting
-println(count(collection, Dict("name"=>"Mokie")))
-println(count(collection))
+println(count(cats, ("name" => "Mokie"))) # 1
+println(count(cats)) # 2
+````
 
+Query Syntax
+------------
+
+MongoDB queries are also BSON documents, and can include certain
+[modifiers](https://docs.mongodb.org/manual/reference/operator/query-modifier/)
+and [operators](https://docs.mongodb.org/manual/reference/operator/query/) which
+allow for the construction of complex queries. This package includes shortcut
+functions for many of them so, for instance instead of typing:
+
+````julia
+Dict("\$query" => Dict("age" => Dict("\$lt" => 19)))
+````
+
+We can do the following:
+
+````julia
 # Print all cats under age 19
-# The query function returns a pair with the key "$query"
-# There are functional shortcuts for many MongoDB modifiers and operators, here
-# we use $lt
-for doc in find(collection, query("age" => lt(19)))
+for doc in find(cats, query("age" => lt(19)))
     println("$(doc["name"]) is younger than 19")
 end
+````
 
+Operators and modifiers can be combined by encasing them in parenthesis.
+
+````julia
 # It's Mokie's birthday!
 # We can use the shortcut for the "$inc" operator to increase Mokie's age by 1
-# Notice how we can use a Tuple as our query instead of typing "Dict" over and over
-update(collection, ("_id"=>m_oid), inc("age"=>1))
-for doc in find(collection, Dict("name"=>"Mokie"))
-    println(doc)
+update(cats, ("_id" => m_oid), inc("age" => 1))
+
+for doc in find(cats, (query(), orderby("age" => 1)))
+    println("$(doc["name"]) is $(doc["age"]) years old.")
 end
 
 # Delete the document and ensure it is no more by counting
-delete(collection, Dict("_id"=>m_oid))
-println(count(collection, Dict("name"=>"Mokie")))
+delete(cats, ("_id" => m_oid))
+println(count(cats, ("name" => "Mokie")))
 ````
 
 Contributing

--- a/src/Mongo.jl
+++ b/src/Mongo.jl
@@ -20,8 +20,11 @@ atexit() do
     ccall((:mongoc_cleanup, libmongoc), Void, ())
 end
 
+typealias NakedDict Union{Pair,Tuple}
+
 include("MongoClient.jl")
 include("MongoCollection.jl")
 include("MongoCursor.jl")
+include("query.jl")
 
 end

--- a/src/MongoCollection.jl
+++ b/src/MongoCollection.jl
@@ -59,6 +59,11 @@ insert(
     dict::Associative;
     flags::Int = MongoInsertFlags.None
     ) = insert(collection, BSONObject(dict), flags=flags)
+insert(
+    collection::MongoCollection,
+    dict::NakedDict;
+    flags::Int = MongoInsertFlags.None
+    ) = insert(collection, BSONObject(Dict(dict)), flags=flags)
 export insert
 
 baremodule MongoUpdateFlags
@@ -97,6 +102,8 @@ update(
         BSONObject(change),
         flags = flags
         )
+update(c::MongoCollection, s::NakedDict, chg::NakedDict; kwargs...) =
+    update(c, BSONObject(Dict(s)), BSONObject(Dict(chg)); kwargs...)
 export update
 
 baremodule MongoQueryFlags
@@ -190,6 +197,10 @@ Base.find(
         batch_size = batch_size,
         flags = flags
         )
+Base.find(c::MongoCollection, s::NakedDict; kwargs...) =
+    find(c, BSONObject(Dict(s)); kwargs...)
+Base.find(c::MongoCollection, s::NakedDict, f::NakedDict; kwargs...) =
+    find(c, BSONObject(Dict(s)), BSONObject(Dict(f)); kwargs...)
 export find
 
 Base.count(
@@ -227,6 +238,9 @@ Base.count(
         limit = limit,
         flags = flags
         )
+Base.count(c::MongoCollection, s::NakedDict; kwargs...) =
+    count(c, BSONObject(Dict(s)); kwargs...)
+Base.count(c::MongoCollection) = count(c, BSONObject())
 export count
 
 baremodule MongoDeleteFlags
@@ -262,6 +276,8 @@ delete(
         BSONObject(selector),
         flags = flags
         )
+delete(c::MongoCollection, s::NakedDict; kwargs...) =
+    delete(c, BSONObject(Dict(s)); kwargs...)
 export delete
 
 destroy(collection::MongoCollection) =

--- a/src/query.jl
+++ b/src/query.jl
@@ -1,0 +1,34 @@
+# Helper functions for common query operators
+
+macro modifier(name::Symbol)
+  quote
+    $(esc(name))(kv::Pair...) = ($(string("\$", name)) => Dict(kv))
+    export $name
+  end
+end
+
+@modifier query
+@modifier orderby
+import Base.max
+import Base.min
+@modifier max
+@modifier min
+@modifier set
+@modifier inc
+
+macro operator(name::Symbol)
+  quote
+    $(esc(name))(x) = Dict($(string("\$", name)) => x)
+    export $name
+  end
+end
+
+@operator gt
+@operator lt
+@operator lte
+@operator gte
+import Base.in
+@operator in
+@operator nin
+@operator ne
+@operator eq

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,5 @@
 using FactCheck, LibBSON, Mongo
 
-mongoDBDir = "/tmp/Mongo.jl-test.db"
-mkpath(mongoDBDir)
-mongod = spawn(`mongod --dbpath $mongoDBDir`)
-sleep(1) # wait for listen on port
-
 facts("Mongo") do
     client = MongoClient()
     collection = MongoCollection(client, "foo", "bar")
@@ -76,6 +71,3 @@ facts("Query building helpers") do
     end
     delete(ppl, ())
 end
-
-kill(mongod)
-rm(mongoDBDir, recursive=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,9 +11,10 @@ facts("Mongo") do
     oid = BSONOID()
 
     context("insert") do
-        insert(collection, Dict("_id" => oid, "hello" => "before"))
-        @fact count(collection, Dict("_id" => oid)) --> 1
-        for item in find(collection, Dict("_id" => oid), Dict("_id" => false, "hello" => true))
+        insert(collection, ("_id" => oid, "hello" => "before"))
+        @fact count(collection, ("_id" => oid)) --> 1
+        @fact count(collection) --> 1
+        for item in find(collection, ("_id" => oid), ("_id" => false, "hello" => true))
             @fact dict(item) --> Dict("hello" => "before")
         end
     end
@@ -21,11 +22,11 @@ facts("Mongo") do
     context("update") do
         update(
             collection,
-            Dict("_id" => oid),
-            Dict("\$set" => Dict("hello" => "after"))
+            ("_id" => oid),
+            set("hello" => "after")
             )
-        @fact count(collection, Dict("_id" => oid)) --> 1
-        for item in find(collection, Dict("_id" => oid), Dict("_id" => false, "hello" => true))
+        @fact count(collection, ("_id" => oid)) --> 1
+        for item in find(collection, ("_id" => oid), ("_id" => false, "hello" => true))
             @fact dict(item) --> Dict("hello" => "after")
         end
     end
@@ -33,16 +34,47 @@ facts("Mongo") do
     context("delete") do
         delete(
             collection,
-            Dict("_id" => oid)
+            ("_id" => oid)
             )
-        @fact count(collection, Dict("_id" => oid)) --> 0
+        @fact count(collection, ("_id" => oid)) --> 0
+        @fact count(collection) --> 0
     end
 end
 
 facts("Mongo: bad host/port") do
     client = MongoClient("bad-host-name", 9999)
     collection = MongoCollection(client, "foo", "bar")
-    @fact_throws insert(collection, Dict("foo" => "bar"))
+    @fact_throws insert(collection, ("foo" => "bar"))
+end
+
+facts("Query building helpers") do
+    client = MongoClient()
+    ppl = MongoCollection(client, "foo", "ppl")
+    person(name, age) = insert(ppl, ("name" => name, "age" => age))
+    person("Tim", 25)
+    person("Jason", 21)
+    person("Jim", 87)
+    context("orderby") do
+        @fact first(find(ppl, (query(), orderby("age" => -1))))["name"] --> "Jim"
+        @fact first(find(ppl, (query(), orderby("age" => 1))))["name"] --> "Jason"
+    end
+    context("gt and lt") do
+        @fact first(find(ppl, query("age" => lt(25))))["name"] --> "Jason"
+        @fact first(find(ppl, query("age" => gt(50))))["name"] --> "Jim"
+    end
+    context("in and nin") do
+        @fact first(find(ppl, query("age" => in([21]))))["name"] --> "Jason"
+        @fact first(find(ppl, query("age" => nin([21,25]))))["name"] --> "Jim"
+    end
+    context("eq and ne") do
+        @fact first(find(ppl, query("age" => eq(21))))["name"] --> "Jason"
+        @fact first(find(ppl, query("age" => ne(87))))["name"] == "Jim" --> false
+    end
+    context("update with operator") do
+        update(ppl, ("age" => 87), set("age" => 88))
+        @fact first(find(ppl, query("name" => "Jim")))["age"] --> 88
+    end
+    delete(ppl, ())
 end
 
 kill(mongod)


### PR DESCRIPTION
Check out the updated README for an explanation. Creates a way to write compact queries without a bunch of `Dict` constructors, i.e.

``` julia
find(collection, (query("job" => "Fireman"), orderby("age" => -1)))
```
