### PR TITLE
Add command simple

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ sudo: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.clone(pwd()); Pkg.build("Mongo")'
-    - julia -e 'Pkg.add("FactCheck"); Pkg.add("BinDeps"); Pkg.add("LibBSON")'
+    - julia -e 'Pkg.add("FactCheck"); Pkg.add("BinDeps"); Pkg.add("LibBSON"); Pkg.add("DataStructures")'
     - julia -e 'Pkg.test("Mongo", coverage=true)'
 after_success:
     - if [ $JULIAVERSION = "juliareleases" ]; then julia -e 'cd(Pkg.dir("Mongo")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi

--- a/README.md
+++ b/README.md
@@ -94,6 +94,42 @@ delete(cats, ("_id" => m_oid))
 println(count(cats, ("name" => "Mokie")))
 ````
 
+Command Syntax
+--------------
+
+The `command_simple` function allows broad access to MongoDB actions. For example, creating an index:
+
+```julia
+command_simple(client,
+               "db",
+               Dict(
+                  "createIndexes" => "cats",
+                  "indexes" => [
+                      Dict(
+                          "key" => Dict("name" => 1),
+                          "name" => "cats_name",
+                          "unique" => 1)
+                      ]
+                  ))
+```
+
+`command_simple` returns a `BSONObject` reply, so you can also perform aggregations:
+
+```julia
+command_simple(client,
+               "db",
+               OrderedDict(
+                  "aggregate" => "cats",
+                  "pipeline" => [
+                      Dict("\$match" => Dict("age" => 19)),
+                      Dict("\$group" => Dict("_id" => "\$name", "count" => Dict("\$sum" => 1)))
+                  ]
+                )
+              )
+```
+
+Refer to the [MongoDB database commands docs](https://docs.mongodb.org/manual/reference/command/) for further commands.
+
 Contributing
 ------------
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 FactCheck
+DataStructures 0.4.2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using FactCheck, LibBSON, Mongo
+using FactCheck, LibBSON, Mongo, DataStructures
 
 facts("Mongo") do
     client = MongoClient()
@@ -24,6 +24,17 @@ facts("Mongo") do
         for item in find(collection, ("_id" => oid), ("_id" => false, "hello" => true))
             @fact dict(item) --> Dict("hello" => "after")
         end
+    end
+
+    context("command_simple") do
+        reply = command_simple(
+            client,
+            "foo",
+            OrderedDict(
+               "count" => "bar",
+               "query" => Dict("_id" => oid))
+            )
+        @fact reply["n"] --> 1
     end
 
     context("delete") do


### PR DESCRIPTION
I've added a binding for `mongo_collection_command_simple`, which allows use of a [whole bunch of MongoDB actions](https://docs.mongodb.org/manual/reference/command/). There is a test case, and a `README` update.

Should solve #13.
