### PR TITLE
Add client, db, and name variables to MongoCollection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ using Mongo, LibBSON
 # Create a client connection
 client = MongoClient() # default locahost:27017
 
-# Get a handle to collection named "cats" in database "db"
+# Get a handle to collection named "cats" in database "db".
+# Client object, database name, and collection name are stored as variables.
 cats = MongoCollection(client, "db", "cats")
 
 # Insert a document

--- a/src/MongoCollection.jl
+++ b/src/MongoCollection.jl
@@ -1,5 +1,8 @@
 type MongoCollection
     _wrap_::Ptr{Void}
+    client::MongoClient
+    db::AbstractString
+    name::AbstractString
 
     MongoCollection(client::MongoClient, db::AbstractString, name::AbstractString) = begin
         dbCStr = bytestring(db)
@@ -9,7 +12,10 @@ type MongoCollection
                 (:mongoc_client_get_collection, libmongoc),
                 Ptr{Void}, (Ptr{Void}, Ptr{UInt8}, Ptr{UInt8}),
                 client._wrap_, dbCStr, nameCStr
-                )
+                ),
+            client,
+            db,
+            name
             )
         finalizer(collection, destroy)
         return collection

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,12 @@ facts("Mongo") do
     collection = MongoCollection(client, "foo", "bar")
     oid = BSONOID()
 
+    context("variables") do
+      @fact collection.client --> client
+      @fact collection.db --> "foo"
+      @fact collection.name --> "bar"
+    end
+
     context("insert") do
         insert(collection, ("_id" => oid, "hello" => "before"))
         @fact count(collection, ("_id" => oid)) --> 1


### PR DESCRIPTION
Adding references to parameters used to create a MongoCollection. This allows using methods like `query` and `command_simple` without having to store/ pass redundant information around.
