### PR TITLE
fix a deprecation and add some convenient methods

### DIFF
--- a/src/MongoCollection.jl
+++ b/src/MongoCollection.jl
@@ -32,7 +32,7 @@ show(io::IO, collection::MongoCollection) = begin
         Ptr{UInt8}, (Ptr{Void},),
         collection._wrap_
         )
-    name = bytestring(nameCStr)
+    name = unsafe_string(nameCStr)
     print(io, "MongoCollection($name)")
 end
 export show

--- a/src/MongoCursor.jl
+++ b/src/MongoCursor.jl
@@ -32,6 +32,11 @@ done(cursor::MongoCursor, _::Void) = begin
 end
 export done
 
+if Base.VERSION > v"0.5.0-"
+Base.iteratorsize(::Type{MongoCursor}) = Base.SizeUnknown()
+end
+Base.eltype(::Type{MongoCursor}) = BSONObject
+
 destroy(collection::MongoCursor) =
     ccall(
         (:mongoc_cursor_destroy, libmongoc),


### PR DESCRIPTION
This tells various iterator functions to avoid trying to call `length` on a `MongoCursor`.
