### PR TITLE
Fix string dep warns

### DIFF
--- a/src/MongoClient.jl
+++ b/src/MongoClient.jl
@@ -1,12 +1,11 @@
 using Compat
-import Compat.UTF8String
 
 type MongoClient
     uri::AbstractString
     _wrap_::Ptr{Void}
 
     MongoClient(uri::AbstractString) = begin
-        uriCStr = Compat.UTF8String(uri)
+        uriCStr = String(uri)
         client = new(
             uri,
             ccall(
@@ -40,7 +39,7 @@ command_simple(
     db_name::AbstractString, # const char
     command::BSONObject#, # const bson_t
     ) = begin
-    dbCStr = Compat.UTF8String(db_name)
+    dbCStr = String(db_name)
     reply = BSONObject() # bson_t
     bsonError = BSONError() # bson_error_t
     ccall(

--- a/src/MongoCollection.jl
+++ b/src/MongoCollection.jl
@@ -1,5 +1,4 @@
 using Compat
-import Compat.UTF8String
 
 type MongoCollection
     _wrap_::Ptr{Void}
@@ -8,8 +7,8 @@ type MongoCollection
     name::AbstractString
 
     MongoCollection(client::MongoClient, db::AbstractString, name::AbstractString) = begin
-        dbCStr = Compat.UTF8String(db)
-        nameCStr = Compat.UTF8String(name)
+        dbCStr = String(db)
+        nameCStr = String(name)
         collection = new(
             ccall(
                 (:mongoc_client_get_collection, libmongoc),


### PR DESCRIPTION
Change `Compat.UTF8String` to `String`. Tested locally on Julia 0.6.